### PR TITLE
Added image save functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'jquery-rails'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+gem 'valid_url'
+
 gem 'webpacker', '~> 4'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'jquery-rails'
 
 gem 'valid_url'
 
+gem 'simple_form'
+
 gem 'webpacker', '~> 4'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,9 @@ GEM
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    simple_form (5.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -238,6 +241,7 @@ DEPENDENCIES
   rails (~> 5.2.0)
   sass-rails (~> 5.0, >= 5.0.6)
   selenium-webdriver
+  simple_form
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,9 @@ GEM
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.0)
+    valid_url (0.0.4)
+      addressable
+      rails
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -240,6 +243,7 @@ DEPENDENCIES
   sqlite3
   tzinfo-data
   uglifier (>= 1.3.0)
+  valid_url
   web-console
   webpacker (~> 4)
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,7 @@
  *= require_tree .
  *= require_self
  */
+
+.main-content {
+  margin-left: 10px;
+}

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,4 +1,9 @@
 class ImagesController < ApplicationController
+  before_action :set_image, only: %i[show]
+
+  # GET /images/1
+  def show; end
+
   # GET /images/new
   def new
     @image = Image.new
@@ -9,15 +14,25 @@ class ImagesController < ApplicationController
     @image = Image.new(image_params)
 
     if @image.save
-      redirect_to root_path
+      redirect_to @image, notice: 'Image was successfully created.'
     else
-      render :new, status: :unprocessable_entity
+      render :new, notice: 'Failed to create the image.', status: :unprocessable_entity
     end
   end
 
   private
 
-  # Only allow a trusted parameter "white list" through.
+  # Use callbacks to share common setup or constraints between actions.
+  def set_image
+    @image = Image.find(show_params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path, notice: 'The specified image could not be found.'
+  end
+
+  def show_params
+    params.permit(:id)
+  end
+
   def image_params
     params.require(:image).permit(:url)
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,24 @@
+class ImagesController < ApplicationController
+  # GET /images/new
+  def new
+    @image = Image.new
+  end
+
+  # POST /images
+  def create
+    @image = Image.new(image_params)
+
+    if @image.save
+      redirect_to root_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  # Only allow a trusted parameter "white list" through.
+  def image_params
+    params.require(:image).permit(:url)
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,3 @@
+class Image < ApplicationRecord
+  validates :url, url: true
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,3 @@
 <h1>Hello, world!</h1>
+
+<%= link_to 'New Image', new_image_path %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,5 @@
+<p id="notice"><%= notice %></p>
+
 <h1>Hello, world!</h1>
 
 <%= link_to 'New Image', new_image_path %>

--- a/app/views/images/_form.html.erb
+++ b/app/views/images/_form.html.erb
@@ -1,0 +1,4 @@
+<%= simple_form_for @image do |f| %>
+  <%= f.input :url %>
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Image</h1>
+
+<%= render 'form', image: @image %>
+
+<%= link_to 'Back', root_path %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,0 +1,5 @@
+<p id="notice"><%= notice %></p>
+
+<img src="<%= @image.url %>"  alt="<%= @image.url %>">
+<br/>
+<%= link_to 'Back', root_path %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/heartcombo/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+                            hint_class: :field_with_hint, error_class: :field_with_errors,
+                            valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'home#index'
-  resources :images, only: %i[new create]
+  resources :images, only: %i[new create show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'home#index'
+  resources :images, only: %i[new create]
 end

--- a/db/migrate/20200622005738_create_images.rb
+++ b/db/migrate/20200622005738_create_images.rb
@@ -1,0 +1,8 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.string :url, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_06_22_005738) do
+
+  create_table "images", force: :cascade do |t|
+    t.string "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/lib/templates/erb/scaffold/_form.html.erb
+++ b/lib/templates/erb/scaffold/_form.html.erb
@@ -1,0 +1,15 @@
+<%# frozen_string_literal: true %>
+<%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
+  <%%= f.error_notification %>
+  <%%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+  <div class="form-inputs">
+  <%- attributes.each do |attribute| -%>
+    <%%= f.<%= attribute.reference? ? :association : :input %> :<%= attribute.name %> %>
+  <%- end -%>
+  </div>
+
+  <div class="form-actions">
+    <%%= f.button :submit %>
+  </div>
+<%% end %>

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -2,8 +2,14 @@ require 'test_helper'
 
 class HomeControllerTest < ActionDispatch::IntegrationTest
   test 'index page displays hello world' do
-    get '/'
+    get root_url
     assert_response :success
     assert_select 'h1', 'Hello, world!'
+  end
+
+  test 'index page has new image link' do
+    get root_url
+    assert_response :success
+    assert_select 'a', 'New Image'
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -11,7 +11,9 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_difference('Image.count', 1) do
       post images_url, params: { image: { url: 'https://github.com/ProbablyFaiz.png' } }
     end
-    assert_redirected_to root_url
+    assert_redirected_to image_url(Image.last)
+    follow_redirect!
+    assert_select 'p#notice', 'Image was successfully created.'
   end
 
   test 'should raise exception for nil image' do
@@ -39,5 +41,19 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
       post images_url, params: { image: { url: 'hello' } }
     end
     assert_select 'span.error', 'is an invalid URL'
+  end
+
+  test 'should show image' do
+    image = Image.create(url: 'https://github.com/ProbablyFaiz.png')
+    get image_url(image)
+    assert_response :success
+    assert_select 'img[alt="' + image.url + '"]'
+  end
+
+  test 'should redirect to root if image does not exist' do
+    get image_url(999)
+    assert_redirected_to root_url
+    follow_redirect!
+    assert_select 'p#notice', 'The specified image could not be found.'
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class ImagesControllerTest < ActionDispatch::IntegrationTest
+  test 'should get new' do
+    get new_image_url
+    assert_response :success
+    assert_select 'h1', 'New Image'
+  end
+
+  test 'should create image for valid url' do
+    assert_difference('Image.count', 1) do
+      post images_url, params: { image: { url: 'https://github.com/ProbablyFaiz.png' } }
+    end
+    assert_redirected_to root_url
+  end
+
+  test 'should raise exception for nil image' do
+    assert_raise do
+      post images_url, params: { image: nil }
+    end
+  end
+
+  test 'should not create image for nil url' do
+    assert_no_difference('Image.count') do
+      post images_url, params: { image: { url: nil } }
+    end
+    assert_select 'span.error', 'is an invalid URL'
+  end
+
+  test 'should not create image for non http/s url type' do
+    assert_no_difference('Image.count') do
+      post images_url, params: { image: { url: 'ftp://example.com/test.png' } }
+    end
+    assert_select 'span.error', 'is an invalid URL'
+  end
+
+  test 'should not create image for non url' do
+    assert_no_difference('Image.count') do
+      post images_url, params: { image: { url: 'hello' } }
+    end
+    assert_select 'span.error', 'is an invalid URL'
+  end
+end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class ImageTest < ActiveSupport::TestCase
+  test 'valid image with valid url' do
+    image = Image.new(url: 'https://github.com/ProbablyFaiz.png')
+    assert image.valid?
+  end
+
+  test 'invalid image when url is nil' do
+    image = Image.new(url: nil)
+    assert image.invalid?
+    assert_equal(image.errors.full_messages, ['Url is an invalid URL'])
+  end
+
+  test 'invalid image when url is wrong type' do
+    image = Image.new(url: 'ftp://example.com/test.png')
+    refute image.valid?
+    assert_equal(image.errors.full_messages, ['Url is an invalid URL'])
+  end
+
+  test 'invalid image when url is not url' do
+    image = Image.new(url: 'hello')
+    refute image.valid?
+    assert_equal(image.errors.full_messages, ['Url is an invalid URL'])
+  end
+end


### PR DESCRIPTION
Closes #3.

This PR adds the functionality of saving image models (only contain URLs right now) to the database via a form. The URLs are validated using the built in ``uri`` library and tests are added to ensure these views and validation work correctly.

